### PR TITLE
Support for multiple cards

### DIFF
--- a/cards/ericsson_business_mobile_networks_bv
+++ b/cards/ericsson_business_mobile_networks_bv
@@ -16,60 +16,60 @@ set -eu
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-# Settings
-SERIAL_DEV=/dev/ttyACM1
+setup() {
+  SERIAL_DEV=/dev/ttyACM1
+  CHAT_TIMEOUT=2
 
-# Check ENFORCE_UMTS
-if [ "$ENFORCE_UMTS" = "no" ]; then
-    AT_CFUN_INFO='wwan-helper: Not enforcing UMTS, allowing for GSM'
-    AT_CFUN_START=1
-elif [ "$ENFORCE_UMTS" = "yes" ]; then
-    AT_CFUN_INFO='wwan-helper: Enforcing UMTS, not allowing for GSM'
-    AT_CFUN_START=6
-else
-    echo 'wwan-helper: Invalid config value for ENFORCE_UMTS'
-    exit 1
-fi
+  # Check ENFORCE_UMTS
+  if [ "$ENFORCE_UMTS" = "no" ]; then
+      verbose "Not enforcing UMTS, allowing for GSM"
+      AT_CFUN_START=1
+  elif [ "$ENFORCE_UMTS" = "yes" ]; then
+      verbose "Enforcing UMTS, not allowing for GSM"
+      AT_CFUN_START=6
+  else
+      fail "Invalid config value for ENFORCE_UMTS"
+  fi
+}
 
-# Check phase
-case "$PHASE" in
-    pre-up)
-        while true; do
-            echo 'wwan-helper: Starting modem'
-            echo "$AT_CFUN_INFO"
-            modprobe cdc_acm
-            ip link set "$IFACE" down || echo "wwan-helper: Error on 'ip link set "$IFACE" down' (ignored)"
-            chat -v -T "$APN" -U "$PIN" \
-                TIMEOUT 2 \
-                '*EMRDY: 1' \
-                'AT+CPIN?' '+CPIN: READY-AT+CPIN="\U"-' \
-                '\c' 'OK' \
-                'AT+CFUN='"$AT_CFUN_START" 'OK' \
-                'AT+CGDCONT=1,"IP","\T"' 'OK' \
-                'AT*ENAP?' '*ENAP:1,""-AT*ENAP=1,1-' \
-                '\c' 'OK' \
-                < "$SERIAL_DEV" > "$SERIAL_DEV" || echo "wwan-helper: Error on 'chat' with $SERIAL_DEV (ignored)"
-            ip link set "$IFACE" up || echo "wwan-helper: Error on 'ip link set "$IFACE" up' (ignored)"
-            sleep "$RETRY_TIMEOUT"
-            if dmesg | grep "cdc_ncm[: ].* $IFACE: network" | tail -1 | grep ' connected$'; then
-                break
-            fi
-            echo 'wwan-helper: Failed - Retrying'
-            rmmod cdc_acm
-        done
-        ;;
-    post-down)
-        echo 'wwan-helper: Shutting down modem'
-        chat -v \
-            TIMEOUT 2 \
-            '*EMRDY: 1' \
-            'AT*ENAP?' '*ENAP:0,""-AT*ENAP=0-' \
-            '\c' 'OK' \
-            'AT+CFUN=4' 'OK' \
-            < "$SERIAL_DEV" > "$SERIAL_DEV"
-        ;;
-    *)
-        # Other phase, nothing to do
-        exit 0
-        ;;
-esac
+init() {
+  ip link set "$IFACE" down
+  modemchat TIMEOUT 2 \
+    '*EMRDY: 1' \
+    'AT+CFUN='"$AT_CFUN_START" 'OK'
+}
+
+unlock() {
+  modemchat -U"$PIN" '' \
+    'AT+CPIN?' TIMEOUT 1 '+CPIN: READY-AT+CPIN="\U"-' \
+    '\c' 'OK'
+}
+
+register() { :; }
+
+connect() {
+  ip link set "$IFACE" up
+  sleep "$RETRY_TIMEOUT"
+  if dmesg | grep "cdc_ncm[: ].* $IFACE: network" | tail -1 | grep ' connected$'; then
+    return 0
+  fi
+  return 1
+}
+
+reset() {
+  rmmod cdc_acm
+  modprobe cdc_acm
+  init
+  unlock
+}
+
+disconnect() {
+  modemchat '*EMRDY: 1' \
+    'AT*ENAP?' '*ENAP:0,""-AT*ENAP=0-' \
+    '\c' 'OK'
+}
+
+shutdown() {
+  modemchat '*EMRDY: 1' \
+    'AT+CFUN=4' 'OK'
+}

--- a/cards/ericsson_business_mobile_networks_bv
+++ b/cards/ericsson_business_mobile_networks_bv
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -eu
+
+# Copyright (C) 2013     Volker Grabsch <v@njh.eu>
+# Copyright (C) 2015,16  Martin Krafft <madduck@madduck.net>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+# Settings
+SERIAL_DEV=/dev/ttyACM1
+
+# Check ENFORCE_UMTS
+if [ "$ENFORCE_UMTS" = "no" ]; then
+    AT_CFUN_INFO='wwan-helper: Not enforcing UMTS, allowing for GSM'
+    AT_CFUN_START=1
+elif [ "$ENFORCE_UMTS" = "yes" ]; then
+    AT_CFUN_INFO='wwan-helper: Enforcing UMTS, not allowing for GSM'
+    AT_CFUN_START=6
+else
+    echo 'wwan-helper: Invalid config value for ENFORCE_UMTS'
+    exit 1
+fi
+
+# Check phase
+case "$PHASE" in
+    pre-up)
+        while true; do
+            echo 'wwan-helper: Starting modem'
+            echo "$AT_CFUN_INFO"
+            modprobe cdc_acm
+            ip link set "$IFACE" down || echo "wwan-helper: Error on 'ip link set "$IFACE" down' (ignored)"
+            chat -v -T "$APN" -U "$PIN" \
+                TIMEOUT 2 \
+                '*EMRDY: 1' \
+                'AT+CPIN?' '+CPIN: READY-AT+CPIN="\U"-' \
+                '\c' 'OK' \
+                'AT+CFUN='"$AT_CFUN_START" 'OK' \
+                'AT+CGDCONT=1,"IP","\T"' 'OK' \
+                'AT*ENAP?' '*ENAP:1,""-AT*ENAP=1,1-' \
+                '\c' 'OK' \
+                < "$SERIAL_DEV" > "$SERIAL_DEV" || echo "wwan-helper: Error on 'chat' with $SERIAL_DEV (ignored)"
+            ip link set "$IFACE" up || echo "wwan-helper: Error on 'ip link set "$IFACE" up' (ignored)"
+            sleep "$RETRY_TIMEOUT"
+            if dmesg | grep "cdc_ncm[: ].* $IFACE: network" | tail -1 | grep ' connected$'; then
+                break
+            fi
+            echo 'wwan-helper: Failed - Retrying'
+            rmmod cdc_acm
+        done
+        ;;
+    post-down)
+        echo 'wwan-helper: Shutting down modem'
+        chat -v \
+            TIMEOUT 2 \
+            '*EMRDY: 1' \
+            'AT*ENAP?' '*ENAP:0,""-AT*ENAP=0-' \
+            '\c' 'OK' \
+            'AT+CFUN=4' 'OK' \
+            < "$SERIAL_DEV" > "$SERIAL_DEV"
+        ;;
+    *)
+        # Other phase, nothing to do
+        exit 0
+        ;;
+esac

--- a/cards/huawei_me906s
+++ b/cards/huawei_me906s
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -eu
+
+# Copyright (C) 2016  Martin Krafft <madduck@madduck.net>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+setup() {
+  SERIAL_DEV=/dev/ttyUSB0
+  CHAT_TIMEOUT=3
+}
+
+INIT_MINWAIT=5 # we need to wait 5 seconds for the device to even disappear on
+INIT_MAXWAIT=15
+
+init() {
+  modemchat '' 'AT+CFUN=1,1' 'OK'
+  verbose_end "started."
+  verbose_begin "Waiting for up to $INIT_MAXWAIT seconds for modem to finish initialising"
+  local i; i=0
+  while [ $i -lt $INIT_MAXWAIT ]; do
+    i=$((i+1))
+    if [ $i -gt $INIT_MINWAIT ] && [ -c "$SERIAL_DEV" ]; then
+      modemchat TIMEOUT 1 '' ATZ OK && return
+    else
+      sleep 1
+    fi
+    verbose_cont .
+  done
+  verbose_end "failed."
+  fail "Modem failed to initialise in $INIT_MAXWAIT seconds"
+}
+
+unlock() {
+  modemchat -U"$PIN" '' \
+    'AT+CPIN?' TIMEOUT 1 '+CPIN: READY-AT+CPIN="\U"-' \
+    '\c' 'OK'
+}
+
+REG_MAXWAIT=120
+
+register() {
+  verbose_end "started."
+  verbose_begin "Waiting for up to $REG_MAXWAIT seconds for network registration"
+  local i; i=0
+  while [ $i -lt $REG_MAXWAIT ]; do
+    i=$((i+1))
+    modemchat TIMEOUT 1 '' 'AT+CREG?' '+CREG: 0,1' && return
+    verbose_cont .
+  done
+  verbose_end "failed."
+  fail "Network registration failed in $REG_MAXWAIT seconds"
+}
+
+connect() {
+  # \136 is the caret (^) character
+  modemchat -T"$APN" ABORT 'NO CARRIER' ABORT ERROR TIMEOUT 30 '' \
+    'AT\136NDISDUP=1,1,"\T"' '\136NDISSTAT: 1,,,"IPV4"'
+}
+
+reset() { :; }
+
+disconnect() {
+  # \136 is the caret (^) character
+  modemchat '' TIMEOUT 30 'AT\136NDISDUP=1,0' '\136NDISSTAT: 0'
+}
+
+shutdown() {
+  modemchat '' 'AT+CFUN=4' OK
+}

--- a/index.html
+++ b/index.html
@@ -87,6 +87,13 @@
       until the UMTS connection is really established.
     </p>
     <p>
+      Other cards are supported, and adding support for
+      new cards is trivial. Have a look at the scripts
+      in the <code>cards/</code> subdirectory, and the
+      symlinks under <code>usbids/</code>, which link the
+      USB IDs of supported cards to the handler scripts.
+    </p>
+    <p>
       The wwan-helper is meant to run as hook script
       for the <em>ifup&nbsp;/&nbsp;ifdown</em> mechanism,
       but should also work on other networking systems.
@@ -115,13 +122,14 @@
     </p>
     <pre>git clone https://github.com/vog/wwan-helper.git /etc/wwan-helper</pre>
     <p>
-      Configure your
+      Use the output of <code>lsusb</code> to identify the USB ID of your
+      WWAN card, and add it to <code>/etc/wwan-helper/config</code>.
+      There, you also need to configure your
       <a href="http://forums.pinstack.com/f24/tcp_apn_wap_gateway_port_carrier_settings-360/">APN</a>
-      and
-      PIN
-      in <code>/etc/wwan-helper/config</code>:
+      and PIN.
     </p>
-    <pre>APN=web.vodafone.de
+    <pre>USBID=0bdb:1911
+APN=web.vodafone.de
 PIN=1234
 ENFORCE_UMTS=no</pre>
     <p>

--- a/usbids/0bdb:1911
+++ b/usbids/0bdb:1911
@@ -1,0 +1,1 @@
+../cards/ericsson_business_mobile_networks_bv

--- a/usbids/0bdb:193e
+++ b/usbids/0bdb:193e
@@ -1,0 +1,1 @@
+../cards/ericsson_business_mobile_networks_bv

--- a/usbids/12d1:15c1
+++ b/usbids/12d1:15c1
@@ -1,0 +1,1 @@
+../cards/huawei_me906s

--- a/wwan-helper
+++ b/wwan-helper
@@ -28,6 +28,8 @@ case "$IFACE" in
 esac
 
 RETRY_TIMEOUT=3
+MAX_RETRIES=0
+VERBOSE=0
 . /etc/wwan-helper/config
 
 if [ -z "${USBID:-}" ]; then
@@ -42,11 +44,114 @@ fi
 # normalise the USB ID: four hex digits, and lower-case
 USBID=$(printf '%04x:%04x' 0x${USBID%:*} 0x${USBID#*:})
 
+LOG_PREFIX="wwan-helper"
+error() {
+  echo >&2 "${LOG_PREFIX}: $@"
+}
+fail() {
+  local retcode
+  case "$1" in
+    ([0-9]*) retcode=$1; shift;;
+    (*) retcode=1;;
+  esac
+  [ -n "${1:-}" ] && error "$@"
+  exit $retcode
+}
+_be_verbose() { [ $VERBOSE -ge 1 ]; }
+_be_really_verbose() { [ $VERBOSE -ge 2 ]; }
+verbose() {
+  ! _be_verbose || echo >&2 "${LOG_PREFIX}: $@"
+}
+verbose_begin() {
+  ! _be_verbose || echo -n >&2 "${LOG_PREFIX}: $@ "
+}
+verbose_cont() {
+  ! _be_verbose || echo -n >&2 "$@"
+}
+verbose_end() {
+  ! _be_verbose || echo >&2 "$@"
+}
+
+modemchat() {
+  local flags; flags=-S
+  ! _be_really_verbose || flags="${flags}vs"
+  chat $flags -t${CHAT_TIMEOUT:-5} "$@" < $SERIAL_DEV > $SERIAL_DEV
+}
+
+_unimplemented() {
+  fail "Function \`$1' not implemented for WWAN card $USBID."
+}
+setup() { :; } # optional
+init() { _unimplemented init; }
+unlock() { _unimplemented unlock; }
+register() { _unimplemented register; }
+connect() { _unimplemented connect; }
+disconnect() { _unimplemented disconnect; }
+reset() { _unimplemented reset; }
+shutdown() { _unimplemented shutdown; }
+teardown() { :; } # optional
+
 SCRIPT="/etc/wwan-helper/usbids/${USBID}"
 if [ -r "$SCRIPT" ] && [ -f "$SCRIPT" ] || [ -L "$SCRIPT" ]; then
   . ${SCRIPT}
-  exit 0
 else
-  echo "wwan-helper: Unsupported WWAN device: ${USBID:-(no USB ID provided)}"
-  exit 1
+  fail "Unsupported WWAN device: ${USBID:-(no USB ID provided)}"
 fi
+
+LOG_PREFIX="${LOG_PREFIX}[$USBID]"
+
+_runstep() {
+  local phase retcode failureisok
+  case "$1" in
+    (setup) phase="Set-up of handler script";;
+    (init) phase="Initialisation of WWAN card";;
+    (unlock) phase="Unlocking of SIM card";;
+    (register) phase="Registering with the network";;
+    (connect) phase="Connecting the carrier";;
+    (disconnect) phase="Disconnecting the carrier"; failureisok=1;;
+    (reset) phase="Resetting the WWAN card"; failureisok=1;;
+    (shutdown) phase="Shut-down of the WWAN card"; failureisok=1;;
+    (teardown) phase="Tear-down of the handler script";;
+  esac
+  verbose_begin "$phase..."
+  $1 || retcode=$?
+  case "${retcode:-0}/${failureisok:-0}" in
+    (0/*) verbose_end "success.";;
+    (*/1) verbose_end "failed (but that's ok).";;
+    (*)
+      verbose_end "failed.";
+      error "$phase failed (retcode=$retcode)"
+      return $retcode
+      ;;
+  esac
+}
+
+_runstep setup
+
+case "$PHASE" in
+  (pre-up)
+    _runstep init || fail $?
+    [ -z "$PIN" ] || _runstep unlock || fail $?
+
+    i=0
+    while :; do
+      _runstep register && _runstep connect && break
+      i=$((i+1))
+      if [ $i -gt $MAX_RETRIES ]; then
+        fail "Maximum number of connection attempts failed"
+      else
+        verbose "Retrying $(($MAX_RETRIES - $i)) more time(s)..."
+      fi
+      _runstep reset
+    done
+    ;;
+
+  (post-down)
+    _runstep disconnect || fail $?
+    _runstep shutdown || fail $?
+    ;;
+
+  (*) :;;
+esac
+
+_runstep teardown

--- a/wwan-helper
+++ b/wwan-helper
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -eu
 
-# Copyright (C) 2013  Volker Grabsch <v@njh.eu>
+# Copyright (C) 2013     Volker Grabsch <v@njh.eu>
+# Copyright (C) 2015,16  Martin Krafft <madduck@madduck.net>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -26,68 +27,18 @@ case "$IFACE" in
         ;;
 esac
 
-# Check device
-if ! lsusb | egrep -q 'ID 0bdb:19(11|3e) Ericsson Business Mobile Networks BV'; then
-    echo 'wwan-helper: Unsupported WWAN device'
-    exit 1
-fi
-
-# Settings
-SERIAL_DEV=/dev/ttyACM1
 RETRY_TIMEOUT=3
 . /etc/wwan-helper/config
 
-# Check ENFORCE_UMTS
-if [ "$ENFORCE_UMTS" = "no" ]; then
-    AT_CFUN_INFO='wwan-helper: Not enforcing UMTS, allowing for GSM'
-    AT_CFUN_START=1
-elif [ "$ENFORCE_UMTS" = "yes" ]; then
-    AT_CFUN_INFO='wwan-helper: Enforcing UMTS, not allowing for GSM'
-    AT_CFUN_START=6
-else
-    echo 'wwan-helper: Invalid config value for ENFORCE_UMTS'
-    exit 1
+if [ -z "${USBID:-}" ]; then
+  USBID=$(lsusb | sed -rne 's,.*ID (0bdb:19(11|3e)) Ericsson Business Mobile Networks BV,\1,p')
 fi
 
-# Check phase
-case "$PHASE" in
-    pre-up)
-        while true; do
-            echo 'wwan-helper: Starting modem'
-            echo "$AT_CFUN_INFO"
-            modprobe cdc_acm
-            ip link set "$IFACE" down || echo "wwan-helper: Error on 'ip link set "$IFACE" down' (ignored)"
-            chat -v -T "$APN" -U "$PIN" \
-                TIMEOUT 2 \
-                '*EMRDY: 1' \
-                'AT+CPIN?' '+CPIN: READY-AT+CPIN="\U"-' \
-                '\c' 'OK' \
-                'AT+CFUN='"$AT_CFUN_START" 'OK' \
-                'AT+CGDCONT=1,"IP","\T"' 'OK' \
-                'AT*ENAP?' '*ENAP:1,""-AT*ENAP=1,1-' \
-                '\c' 'OK' \
-                < "$SERIAL_DEV" > "$SERIAL_DEV" || echo "wwan-helper: Error on 'chat' with $SERIAL_DEV (ignored)"
-            ip link set "$IFACE" up || echo "wwan-helper: Error on 'ip link set "$IFACE" up' (ignored)"
-            sleep "$RETRY_TIMEOUT"
-            if dmesg | grep "cdc_ncm[: ].* $IFACE: network" | tail -1 | grep ' connected$'; then
-                break
-            fi
-            echo 'wwan-helper: Failed - Retrying'
-            rmmod cdc_acm
-        done
-        ;;
-    post-down)
-        echo 'wwan-helper: Shutting down modem'
-        chat -v \
-            TIMEOUT 2 \
-            '*EMRDY: 1' \
-            'AT*ENAP?' '*ENAP:0,""-AT*ENAP=0-' \
-            '\c' 'OK' \
-            'AT+CFUN=4' 'OK' \
-            < "$SERIAL_DEV" > "$SERIAL_DEV"
-        ;;
-    *)
-        # Other phase, nothing to do
-        exit 0
-        ;;
-esac
+SCRIPT="/etc/wwan-helper/usbids/${USBID}"
+if [ -r "$SCRIPT" ] && [ -f "$SCRIPT" ] || [ -L "$SCRIPT" ]; then
+  . ${SCRIPT}
+  exit 0
+else
+  echo "wwan-helper: Unsupported WWAN device: ${USBID:-(no USB ID provided)}"
+  exit 1
+fi

--- a/wwan-helper
+++ b/wwan-helper
@@ -31,8 +31,16 @@ RETRY_TIMEOUT=3
 . /etc/wwan-helper/config
 
 if [ -z "${USBID:-}" ]; then
-  USBID=$(lsusb | sed -rne 's,.*ID (0bdb:19(11|3e)) Ericsson Business Mobile Networks BV,\1,p')
+  USBID=$(sed -rne 's|^PRODUCT=([[:xdigit:]]{1,4})/([[:xdigit:]]{1,4}).*|\1:\2|p' \
+    /sys/class/net/${IFACE}/device/uevent)
+
+  if [ -z "${USBID:-}" ]; then
+    fail "Could not auto-detect the USB ID."
+  fi
 fi
+
+# normalise the USB ID: four hex digits, and lower-case
+USBID=$(printf '%04x:%04x' 0x${USBID%:*} 0x${USBID#*:})
 
 SCRIPT="/etc/wwan-helper/usbids/${USBID}"
 if [ -r "$SCRIPT" ] && [ -f "$SCRIPT" ] || [ -L "$SCRIPT" ]; then


### PR DESCRIPTION
Handling of multiple different cards

This pull request separates card-specific logic into individual handler scripts, which are accessed through symlinks named after the USB IDs of the cards they handle.

So far, only the existing Ericsson cards are provided, but work on the Huawei ME906s has begun.