### PR TITLE
[huawei] Fix disconnection

### DIFF
--- a/cards/huawei_me906s
+++ b/cards/huawei_me906s
@@ -94,7 +94,7 @@ reset() { :; }
 
 disconnect() {
   # \136 is the caret (^) character
-  modemchat '' TIMEOUT 30 'AT\136NDISDUP=1,0' '\136NDISSTAT: 0'
+  modemchat TIMEOUT 30 '' 'AT\136NDISDUP=1,0' '\136NDISSTAT: 0'
 }
 
 shutdown() {


### PR DESCRIPTION
The chat parameters were out of order, so this fixes things, and now causes disconnection to work properly.