### PR TITLE
Fix roaming registration for Huawei ME906s card

### DIFF
--- a/cards/huawei_me906s
+++ b/cards/huawei_me906s
@@ -69,7 +69,7 @@ register() {
       4) # abort on first condition, i.e. registered to home network
          verbose_cont "registered to home network, "; return;;
       5) # abort on second condition, i.e. registered to foreign network
-         if [ $roaming = enabled ]; then
+         if [ $roaming != enabled ]; then
            verbose_cont "failed (roaming disabled), "
            return 1
          else


### PR DESCRIPTION
There was a silly typo causing the script to report failure when in fact
it had registered to the roaming network just fine.

Signed-off-by: martin f. krafft <madduck@madduck.net>